### PR TITLE
script to check for commit signatures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  signed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: COLOR=1 ./bin/ensure_signed.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets._GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/bin/ensure_signed.sh
+++ b/bin/ensure_signed.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+cd -- "$(dirname "$0")/../lib"
+. ./git.sh
+cd - >/dev/null
+
+ensure_signed

--- a/lib.sh
+++ b/lib.sh
@@ -322,11 +322,6 @@ nofixups() {
     return
   fi
 
-  if [ -n "${CHECK_SIGS-}" ]; then
-    if [ ! "$(ensure_signed)" ]; then
-      return 1
-    fi
-  fi
   commits="$(git log --grep='fixup!' --format=%h ${GIT_BASE:+"$GIT_BASE..HEAD"})"
   if [ -n "$commits" ]; then
     echo "$commits" | FGCOLOR=1 logpcat 'fixup detected'
@@ -335,6 +330,11 @@ nofixups() {
 }
 
 ensure_signed() {
+  ensure_git_base
+  if [ "$(git_commit_count)" -lt 1 ]; then
+    return
+  fi
+
   # look for signature status N: no signature
   if [ ! "$(git log --format="%G?" ${GIT_BASE:+"$GIT_BASE..HEAD"} | grep "N")" ]; then
     return

--- a/lib/git.sh
+++ b/lib/git.sh
@@ -164,11 +164,6 @@ nofixups() {
     return
   fi
 
-  if [ -n "${CHECK_SIGS-}" ]; then
-    if [ ! "$(ensure_signed)" ]; then
-      return 1
-    fi
-  fi
   commits="$(git log --grep='fixup!' --format=%h ${GIT_BASE:+"$GIT_BASE..HEAD"})"
   if [ -n "$commits" ]; then
     echo "$commits" | FGCOLOR=1 logpcat 'fixup detected'
@@ -177,6 +172,11 @@ nofixups() {
 }
 
 ensure_signed() {
+  ensure_git_base
+  if [ "$(git_commit_count)" -lt 1 ]; then
+    return
+  fi
+
   # look for signature status N: no signature
   if [ ! "$(git log --format="%G?" ${GIT_BASE:+"$GIT_BASE..HEAD"} | grep "N")" ]; then
     return

--- a/lib/git.sh
+++ b/lib/git.sh
@@ -163,8 +163,11 @@ nofixups() {
   if [ "$(git_commit_count)" -lt 1 ]; then
     return
   fi
-  if [ ! "$(ensure_signed)" ]; then
-    return 1
+
+  if [ -n "${CHECK_SIGS-}" ]; then
+    if [ ! "$(ensure_signed)" ]; then
+      return 1
+    fi
   fi
   commits="$(git log --grep='fixup!' --format=%h ${GIT_BASE:+"$GIT_BASE..HEAD"})"
   if [ -n "$commits" ]; then

--- a/lib/git.sh
+++ b/lib/git.sh
@@ -163,11 +163,24 @@ nofixups() {
   if [ "$(git_commit_count)" -lt 1 ]; then
     return
   fi
+  if [ ! "$(ensure_signed)" ]; then
+    return 1
+  fi
   commits="$(git log --grep='fixup!' --format=%h ${GIT_BASE:+"$GIT_BASE..HEAD"})"
   if [ -n "$commits" ]; then
     echo "$commits" | FGCOLOR=1 logpcat 'fixup detected'
     return 1
   fi
+}
+
+ensure_signed() {
+  # look for signature status N: no signature
+  if [ ! "$(git log --format="%G?" ${GIT_BASE:+"$GIT_BASE..HEAD"} | grep "N")" ]; then
+    return
+  fi
+  # print the hash and summary of the unsigned commits
+  echo "$(git log --format="%G? %h %s" ${GIT_BASE:+"$GIT_BASE..HEAD"} | grep "^N " | cut -d " " -f 2- )" | FGCOLOR=1 logpcat 'found unsigned commit'
+  return 1
 }
 
 git_commit_count() {


### PR DESCRIPTION
## Summary

Adds a check for commit signatures `ensure_signed.sh`

## Details
- this will allow the CI status to report missing commit signatures clearly to PR submitters in the list of checks
- update for d2 here: https://github.com/terrastruct/d2/pull/1645

### example

<img width="997" alt="Screenshot 2023-10-05 at 3 20 19 PM" src="https://github.com/terrastruct/ci/assets/85081687/a683ee58-15d4-43b7-8a8a-5e5e05f8e32a">

<img width="812" alt="Screenshot 2023-10-05 at 3 20 38 PM" src="https://github.com/terrastruct/ci/assets/85081687/f301c8f8-84b6-4667-83c4-fca142b23b1b">
