### PR TITLE
fix checking commit signature when signed with ssh key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .changed-files
+.emptyAllowedSigners

--- a/lib.sh
+++ b/lib.sh
@@ -335,13 +335,25 @@ ensure_signed() {
     return
   fi
 
-  # look for signature status N: no signature
+  setup_allowed_signers
+  # look for signature status N: no signature (verification done by github)
   if [ ! "$(git log --format="%G?" ${GIT_BASE:+"$GIT_BASE..HEAD"} | grep "N")" ]; then
     return
   fi
   # print the hash and summary of the unsigned commits
   echo "$(git log --format="%G? %h %s" ${GIT_BASE:+"$GIT_BASE..HEAD"} | grep "^N " | cut -d " " -f 2- )" | FGCOLOR=1 logpcat 'found unsigned commit'
   return 1
+}
+
+setup_allowed_signers() {
+  # we only care if a signature is present (github will verify) so we don't need any entries,
+  # but "gpg.ssh.allowedSignersFile needs to be configured and exist for ssh signature verification"
+  if git config --get gpg.ssh.allowedSignersFile >/dev/null; then
+    return
+  fi
+  allowed_signers=".emptyAllowedSigners"
+  touch $allowed_signers
+  git config --local gpg.ssh.allowedSignersFile "$allowed_signers"
 }
 
 git_commit_count() {

--- a/lib/git.sh
+++ b/lib/git.sh
@@ -177,13 +177,25 @@ ensure_signed() {
     return
   fi
 
-  # look for signature status N: no signature
+  setup_allowed_signers
+  # look for signature status N: no signature (verification done by github)
   if [ ! "$(git log --format="%G?" ${GIT_BASE:+"$GIT_BASE..HEAD"} | grep "N")" ]; then
     return
   fi
   # print the hash and summary of the unsigned commits
   echo "$(git log --format="%G? %h %s" ${GIT_BASE:+"$GIT_BASE..HEAD"} | grep "^N " | cut -d " " -f 2- )" | FGCOLOR=1 logpcat 'found unsigned commit'
   return 1
+}
+
+setup_allowed_signers() {
+  # we only care if a signature is present (github will verify) so we don't need any entries,
+  # but "gpg.ssh.allowedSignersFile needs to be configured and exist for ssh signature verification"
+  if git config --get gpg.ssh.allowedSignersFile >/dev/null; then
+    return
+  fi
+  allowed_signers=".emptyAllowedSigners"
+  touch $allowed_signers
+  git config --local gpg.ssh.allowedSignersFile "$allowed_signers"
 }
 
 git_commit_count() {


### PR DESCRIPTION
## Summary

Fixes checking if a commit is signed to work when it is signed with an ssh key.

## Details
- If a commit is signed with an ssh key, git needs the `gpg.ssh.allowedSignersFile` to be configured otherwise it will output an error message.
- this configures it with an empty file to successfully output the commit signature status
- the CI step is to check if a commit is signed at all (status != N (not signed)), not to verify the signature (github will do that), so we just need an empty file and the ssh-signed commit's status will be U (unknown validity)

